### PR TITLE
feature(dates) set the milliseconds to zero

### DIFF
--- a/src/autotemplate.ts
+++ b/src/autotemplate.ts
@@ -46,6 +46,7 @@ const fakeColumn = (table: Table, field: string, type: any) => {
           date = faker.date.recent()
           break
       }
+      date.setMilliseconds(0)
       return date
     case 'VARCHAR':
     case 'TEXT':


### PR DESCRIPTION
<img width="532" alt="image" src="https://user-images.githubusercontent.com/1642974/58145587-c7cc9680-7ca6-11e9-967c-d86975e6de0e.png">

We can give dates with milliseconds to sequelize, but when these are returned the milliseconds are omitted.

Instead of stripping the date values from tests, I want to set the millisecond to zero for dates that are created by `@mishguru/make` 